### PR TITLE
Merged case and name length conflicts

### DIFF
--- a/Employee.Test.Git.Merge/Employee.Test.Git.Merge/Services/TestService.cs
+++ b/Employee.Test.Git.Merge/Employee.Test.Git.Merge/Services/TestService.cs
@@ -17,7 +17,7 @@ namespace Employee.Test.Git.Merge.Services
 
         public List<string> PeopleNames()
         {
-            return _testRepository.GetPeopleNames();
+            return _testRepository.GetPeopleNames().Select(name => name.ToUpper()).ToList();
         }
     }
 }

--- a/Employee.Test.Git.Merge/Employee.Test.Git.Merge/Services/TestService.cs
+++ b/Employee.Test.Git.Merge/Employee.Test.Git.Merge/Services/TestService.cs
@@ -17,7 +17,11 @@ namespace Employee.Test.Git.Merge.Services
 
         public List<string> PeopleNames()
         {
-            return _testRepository.GetPeopleNames();
+            var peopleNames = _testRepository.GetPeopleNames();
+
+            List<string> noShortFirstNames = peopleNames.Where(name => name.Split(' ')[0].Length > 3).ToList();
+
+            return noShortFirstNames;
         }
     }
 }


### PR DESCRIPTION
Peoples name will be uppercased and those less then 4 characters will be excluded.