### PR TITLE
Merged branches and fixed conflicts

### DIFF
--- a/Employee.Test.Git.Merge/Employee.Test.Git.Merge/Services/TestService.cs
+++ b/Employee.Test.Git.Merge/Employee.Test.Git.Merge/Services/TestService.cs
@@ -17,10 +17,10 @@ namespace Employee.Test.Git.Merge.Services
 
         public List<string> PeopleNames()
         {
-            var peopleNames = _testRepository.GetPeopleNames();
+            var peopleNames = _testRepository.GetPeopleNames().Select(name => name.ToUpper());
 
             List<string> noShortFirstNames = peopleNames.Where(name => 
-                name.ToUpper().Split(' ')[0].Length > 3).ToList();
+            	name.Split(' ')[0].Length > 3).ToList();
 
             return noShortFirstNames;
         }

--- a/Employee.Test.Git.Merge/Employee.Test.Git.Merge/Services/TestService.cs
+++ b/Employee.Test.Git.Merge/Employee.Test.Git.Merge/Services/TestService.cs
@@ -17,7 +17,7 @@ namespace Employee.Test.Git.Merge.Services
 
         public List<string> PeopleNames()
         {
-            return _testRepository.GetPeopleNames();
+            return _testRepository.GetPeopleNames().Select(name => name.ToUpper()).ToList();
         }
     }
 }

--- a/Employee.Test.Git.Merge/Employee.Test.Git.Merge/Services/TestService.cs
+++ b/Employee.Test.Git.Merge/Employee.Test.Git.Merge/Services/TestService.cs
@@ -17,7 +17,11 @@ namespace Employee.Test.Git.Merge.Services
 
         public List<string> PeopleNames()
         {
-            return _testRepository.GetPeopleNames();
+            var peopleNames = _testRepository.GetPeopleNames();
+
+            List<string> noShortFirstNames = peopleNames.Where(name => name.Split(' ')[0].Length > 3).ToList();
+
+            return noShortFirstNames;
         }
     }
 }


### PR DESCRIPTION
PeopleNames() method now has both of the functionalities. It turns all names to uppercase and returns only names with length > 4